### PR TITLE
Fix issue #2 - Ensuring backgrounds on sections can be overwritten fr…

### DIFF
--- a/style.css
+++ b/style.css
@@ -2350,10 +2350,15 @@ body {
 .content-area article:last-child,
 .content-area section, /* section is for 404.php and content-none.php */
 .page .content-area article {
-	background-image: none!important;
 	border-bottom: 0;
 	margin-bottom: 24px;
 	margin-bottom: 1.5rem;
+}
+/* Remove the background on articles in the main content area. */
+.attachment .content-area article,
+.content-area article:last-child,
+.page .content-area article {
+	background-image: none!important;
 }
 .archive .content-area article,
 .blog .content-area article,


### PR DESCRIPTION
…om style.css (#3)

* Ensure section backgrounds can be set in child-theme
Fixing https://github.com/mtomas7/tiny-framework/issues/2

* Revert "Ensure section backgrounds can be set in child-theme Fixing https://github.com/mtomas7/tiny-framework/issues/2"

This reverts commit 364f647

* Ensure section backgrounds can be set in child-theme (no code style)
Fixing https://github.com/mtomas7/tiny-framework/issues/2